### PR TITLE
fixes #5 -- removing CookieConfig string from en and qqq

### DIFF
--- a/JSON/en/en.json
+++ b/JSON/en/en.json
@@ -4,7 +4,6 @@
             "dpvc"
         ]
     },
-    "CookieConfig": "MathJax has found a user configuration cookie that includes code to be run. Do you want to run it?\n\n(You should press Cancel unless you set up the cookie yourself.)",
     "MathProcessingError": "Math processing error",
     "MathError": "Math error",
     "LoadFile": "Loading $1",

--- a/JSON/qqq/qqq.json
+++ b/JSON/qqq/qqq.json
@@ -5,7 +5,6 @@
 			"fred"
 		]
 	},
-	"CookieConfig": "This alert message is displayed when the MathJax cookie contains some data with URL or Config properties. These properties may be used to ask MathJax to perform actions during the Configuration phase: either loading a javascript file (URL property) or executing a configuration function (Config property). Note that the character '\\n' is used to specify new lines inside the alert box.",
 	"MathProcessingError": "This message appears when a Javascript error happens during the processing of a mathematical element.",
 	"MathError": "This message appears instead of 'Math Processing Error' when the obsolete Accessible configuration is used.",
 	"LoadFile": "This appears in the MathJax message box when a file is loading. Parameters:\n* $1 - the file name\n{{Identical|Loading}}",


### PR DESCRIPTION
this should allow translatewiki.net to remove CookieConfig from all other locales automatically; see @siebrand's comments at #5
